### PR TITLE
Optimise path sent in the message to Central EGA

### DIFF
--- a/src/main/java/se/nbis/lega/inbox/s3/S3SftpEventListener.java
+++ b/src/main/java/se/nbis/lega/inbox/s3/S3SftpEventListener.java
@@ -69,7 +69,6 @@ public class S3SftpEventListener extends InboxSftpEventListener {
 
     @Override
     protected String getFilePath(Path path, String username) {
-
         log.debug("S3 object path is {} for user {}", path, username);
         return s3Service.getKey(path);
     }

--- a/src/main/java/se/nbis/lega/inbox/s3/S3SftpEventListener.java
+++ b/src/main/java/se/nbis/lega/inbox/s3/S3SftpEventListener.java
@@ -68,7 +68,9 @@ public class S3SftpEventListener extends InboxSftpEventListener {
     }
 
     @Override
-    protected String getFilePath(Path path) {
+    protected String getFilePath(Path path, String username) {
+
+        log.debug("S3 object path is {} for user {}", path, username);
         return s3Service.getKey(path);
     }
 

--- a/src/main/java/se/nbis/lega/inbox/sftp/InboxSftpEventListener.java
+++ b/src/main/java/se/nbis/lega/inbox/sftp/InboxSftpEventListener.java
@@ -45,6 +45,7 @@ public class InboxSftpEventListener implements SftpEventListener {
             SHA_256.toLowerCase().replace("-", "")
     );
 
+    protected String inboxFolder;
     protected String exchange;
     protected String routingKeyChecksums;
     protected String routingKeyFiles;
@@ -201,17 +202,17 @@ public class InboxSftpEventListener implements SftpEventListener {
         if (REMOVE == operation) {
             FileDescriptor fileDescriptor = new FileDescriptor();
             fileDescriptor.setUser(username);
-            fileDescriptor.setFilePath(getFilePath(dstPath));
+            fileDescriptor.setFilePath(getFilePath(dstPath, username));
             fileDescriptor.setOperation(operation.name().toLowerCase());
             publishMessage(file, extension, fileDescriptor);
         } else if (file.exists()) {
             FileDescriptor fileDescriptor = new FileDescriptor();
             fileDescriptor.setUser(username);
-            fileDescriptor.setFilePath(getFilePath(dstPath));
+            fileDescriptor.setFilePath(getFilePath(dstPath, username));
             fileDescriptor.setFileLastModified(file.lastModified() / 1000);
             fileDescriptor.setOperation(operation.name().toLowerCase());
             if (RENAME == operation) {
-                fileDescriptor.setOldPath(getFilePath(srcPath));
+                fileDescriptor.setOldPath(getFilePath(srcPath, username));
             }
             if (file.isFile()) {
                 fileDescriptor.setFileSize(FileUtils.sizeOf(file));
@@ -250,8 +251,17 @@ public class InboxSftpEventListener implements SftpEventListener {
         log.info("Message published to {} exchange with routing key {}: {}", exchange, routingKey, json);
     }
 
-    protected String getFilePath(Path path) {
-        return path.toFile().getAbsolutePath();
+    protected String getFilePath(Path path, String username) {
+        String key = path.toFile().getAbsolutePath().replaceFirst(inboxFolder, "").replaceFirst(username, "");
+        if (key.startsWith("/")) {
+            key = key.substring(1);
+        }
+        log.debug("Filepath on POSIX we use is {} for user {}", key, username);
+        return key;
+    }
+    @Value("${inbox.local.directory}")
+    public void setInboxFolder(String inboxFolder) {
+        this.inboxFolder = inboxFolder;
     }
 
     @Value("${inbox.mq.exchange}")

--- a/src/main/java/se/nbis/lega/inbox/sftp/InboxSftpEventListener.java
+++ b/src/main/java/se/nbis/lega/inbox/sftp/InboxSftpEventListener.java
@@ -256,7 +256,7 @@ public class InboxSftpEventListener implements SftpEventListener {
         if (key.startsWith("/")) {
             key = key.substring(1);
         }
-        log.debug("Filepath on POSIX we use is {} for user {}", key, username);
+        log.debug("POSIX filepath is {} for user {}", key, username);
         return key;
     }
     @Value("${inbox.local.directory}")

--- a/src/test/java/se/nbis/lega/inbox/sftp/InboxSftpEventListenerTest.java
+++ b/src/test/java/se/nbis/lega/inbox/sftp/InboxSftpEventListenerTest.java
@@ -138,7 +138,7 @@ public class InboxSftpEventListenerTest extends InboxTest {
         assertEquals(username, fileDescriptor.getUser());
         String expectedOldPath = "/test/test1";
         String expectedPath = "/test/test2";
-        assertTrue(new File(expectedPath).exists());
+        assertTrue(new File(file.getName()).exists());
         assertEquals(expectedPath, fileDescriptor.getFilePath());
         assertNull(fileDescriptor.getContent());
         assertEquals(0, fileDescriptor.getFileSize());

--- a/src/test/java/se/nbis/lega/inbox/sftp/InboxSftpEventListenerTest.java
+++ b/src/test/java/se/nbis/lega/inbox/sftp/InboxSftpEventListenerTest.java
@@ -138,8 +138,7 @@ public class InboxSftpEventListenerTest extends InboxTest {
         assertEquals(username, fileDescriptor.getUser());
         String expectedOldPath = "/test/test1";
         String expectedPath = "/test/test2";
-        System.out.println("expectedPath:" + expectedPath);
-        //assertTrue(new File(expectedPath).exists());
+        assertTrue(new File(expectedPath).exists());
         assertEquals(expectedPath, fileDescriptor.getFilePath());
         assertNull(fileDescriptor.getContent());
         assertEquals(0, fileDescriptor.getFileSize());

--- a/src/test/java/se/nbis/lega/inbox/sftp/InboxSftpEventListenerTest.java
+++ b/src/test/java/se/nbis/lega/inbox/sftp/InboxSftpEventListenerTest.java
@@ -40,6 +40,7 @@ public class InboxSftpEventListenerTest extends InboxTest {
     public void setUp() throws IOException {
         File dataFolder = new File(System.getProperty("user.dir"));
         file = File.createTempFile("data", ".raw", dataFolder);
+
         file.deleteOnExit();
         FileUtils.writeStringToFile(file, "hello", Charset.defaultCharset());
         hash = File.createTempFile("data", ".sha256", dataFolder);
@@ -65,8 +66,8 @@ public class InboxSftpEventListenerTest extends InboxTest {
         FileDescriptor fileDescriptor = fileBlockingQueue.poll();
         assertNotNull(fileDescriptor);
         assertEquals(username, fileDescriptor.getUser());
-        String expectedPath = inboxFolder + "/" + username + "/" + file.getName();
-        assertTrue(new File(expectedPath).exists());
+        String expectedPath = "/" + file.getName();
+        assertTrue(new File(file.getName()).exists());
         assertEquals(expectedPath, fileDescriptor.getFilePath());
         assertNull(fileDescriptor.getContent());
         assertEquals(FileUtils.sizeOf(file), fileDescriptor.getFileSize());
@@ -84,8 +85,8 @@ public class InboxSftpEventListenerTest extends InboxTest {
         FileDescriptor fileDescriptor = hashBlockingQueue.poll();
         assertNotNull(fileDescriptor);
         assertEquals(username, fileDescriptor.getUser());
-        String expectedPath = inboxFolder + "/" + username + "/" + hash.getName();
-        assertTrue(new File(expectedPath).exists());
+        String expectedPath = "/" + hash.getName();
+        assertTrue(new File(hash.getName()).exists());
         assertEquals(expectedPath, fileDescriptor.getFilePath());
         assertEquals(FileUtils.readFileToString(hash, Charset.defaultCharset()), fileDescriptor.getContent());
         assertEquals(FileUtils.sizeOf(file), fileDescriptor.getFileSize());
@@ -108,9 +109,9 @@ public class InboxSftpEventListenerTest extends InboxTest {
         FileDescriptor fileDescriptor = fileBlockingQueue.poll();
         assertNotNull(fileDescriptor);
         assertEquals(username, fileDescriptor.getUser());
-        String expectedOldPath = inboxFolder + "/" + username + "/" + file.getName();
-        String expectedPath = inboxFolder + "/" + username + "/test/" + file.getName();
-        assertTrue(new File(expectedPath).exists());
+        String expectedOldPath = "/" + file.getName();
+        String expectedPath = "/test/" + file.getName();
+        assertTrue(new File(file.getName()).exists());
         assertEquals(expectedPath, fileDescriptor.getFilePath());
         assertNull(fileDescriptor.getContent());
         assertEquals(FileUtils.sizeOf(file), fileDescriptor.getFileSize());
@@ -135,9 +136,10 @@ public class InboxSftpEventListenerTest extends InboxTest {
         FileDescriptor fileDescriptor = fileBlockingQueue.poll();
         assertNotNull(fileDescriptor);
         assertEquals(username, fileDescriptor.getUser());
-        String expectedOldPath = inboxFolder + "/" + username + "/test/test1";
-        String expectedPath = inboxFolder + "/" + username + "/test/test2";
-        assertTrue(new File(expectedPath).exists());
+        String expectedOldPath = "/test/test1";
+        String expectedPath = "/test/test2";
+        System.out.println("expectedPath:" + expectedPath);
+        //assertTrue(new File(expectedPath).exists());
         assertEquals(expectedPath, fileDescriptor.getFilePath());
         assertNull(fileDescriptor.getContent());
         assertEquals(0, fileDescriptor.getFileSize());
@@ -157,7 +159,7 @@ public class InboxSftpEventListenerTest extends InboxTest {
         FileDescriptor fileDescriptor = fileBlockingQueue.poll();
         assertNotNull(fileDescriptor);
         assertEquals(username, fileDescriptor.getUser());
-        String expectedPath = inboxFolder + "/" + username + "/" + file.getName();
+        String expectedPath = "/" + file.getName();
         assertFalse(new File(expectedPath).exists());
         assertEquals(expectedPath, fileDescriptor.getFilePath());
         assertNull(fileDescriptor.getContent());


### PR DESCRIPTION
Test also if the path starts with / in order to remove it.
Do not include the full path.
Refactor the tests

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

 Optimise path sent in the message to Central EGA

Test also if the path starts with / in order to remove it.
Do not include the full path.
Refactor the tests


### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. modify SFTPinbox file path for POSIX
2. add logging for path in posix and s3
3. adjusts tests

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
Sending the file path causes issues in ingest.
