### PR TITLE
Bugfix/security update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mvn clean install -DskipTests --no-transfer-progress
 
 FROM eclipse-temurin:19-alpine
 
-RUN apk add --no-cache ca-certificates java-cacerts \
+RUN apk add --no-cache --upgrade ca-certificates java-cacerts libssl3 libcrypto3 \
     && ln -sf /etc/ssl/certs/java/cacerts $JAVA_HOME/lib/security/cacerts
 
 RUN addgroup -g 1000 lega && \

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
trying to update dependencies mentioned in security tab

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- update dockerfile with apk upgrade and add libssl3 and libcrypto3 to trigger update
- update snakeyaml package in pom.xml

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
locally it seems to remove all security issues

```
➜ docker run --rm -v /tmp/trivy:/root/.cache -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:0.37.3 image neicnordic/sda-inbox-sftp:4
2023-03-30T11:21:08.001Z	INFO	Vulnerability scanning is enabled
2023-03-30T11:21:08.001Z	INFO	Secret scanning is enabled
2023-03-30T11:21:08.001Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-03-30T11:21:08.001Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.37/docs/secret/scanning/#recommendation for faster secret detection
2023-03-30T11:21:08.004Z	INFO	Detected OS: alpine
2023-03-30T11:21:08.004Z	INFO	Detecting Alpine vulnerabilities...
2023-03-30T11:21:08.006Z	INFO	Number of language-specific files: 1
2023-03-30T11:21:08.006Z	INFO	Detecting jar vulnerabilities...

neicnordic/sda-inbox-sftp:4 (alpine 3.17.2)
===========================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```